### PR TITLE
Added geetest support for deathbycaptcha.com service

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ if __name__ == '__main__':
 | [azcaptcha.com](https://azcaptcha.com) | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
 | [captcha.guru](https://captcha.guru/ru/reg/?ref=127872) | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ |
 | [cptch.net](https://cptch.net/auth/signup?frm=0ebc1ab34eb04f67ac320f020a8f709f) | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| [deathbycaptcha.com](http://deathbycaptcha.com) | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| [deathbycaptcha.com](http://deathbycaptcha.com) | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ |
 | [rucaptcha.com](https://rucaptcha.com?from=9863637) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ### Image CAPTCHA
@@ -83,7 +83,7 @@ if __name__ == '__main__':
 | [azcaptcha.com](https://azcaptcha.com/) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Latin | ✅ |
 | [captcha.guru](https://captcha.guru/ru/reg/?ref=127872) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Latin | ✅ |
 | [cptch.net](https://cptch.net/auth/signup?frm=0ebc1ab34eb04f67ac320f020a8f709f) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Cyrillic/Latin | ❌ |
-| [deathbycaptcha.com](http://deathbycaptcha.com) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Latin | ❌ |
+| [deathbycaptcha.com](http://deathbycaptcha.com) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | Latin | ❌ |
 | [rucaptcha.com](https://rucaptcha.com?from=9863637) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | Cyrillic/Latin | ✅ |
 
 ### Text CAPTCHA
@@ -112,7 +112,7 @@ if __name__ == '__main__':
 | [azcaptcha.com](https://azcaptcha.com/) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
 | [captcha.guru](https://captcha.guru/ru/reg/?ref=127872) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
 | [cptch.net](https://cptch.net/auth/signup?frm=0ebc1ab34eb04f67ac320f020a8f709f) | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| [deathbycaptcha.com](http://deathbycaptcha.com) | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| [deathbycaptcha.com](http://deathbycaptcha.com) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ |
 | [rucaptcha.com](https://rucaptcha.com?from=9863637) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 <sup>1</sup> Support of solving reCAPTCHA on Google services (e.g. Google Search) </br>
@@ -128,7 +128,7 @@ if __name__ == '__main__':
 | [azcaptcha.com](https://azcaptcha.com/) | ✅ | ❌ | ✅ | ❌ | ❌ |
 | [captcha.guru](https://captcha.guru/ru/reg/?ref=127872) | ✅ | ❌ | ✅ | ✅ | ✅ |
 | [cptch.net](https://cptch.net/auth/signup?frm=0ebc1ab34eb04f67ac320f020a8f709f) | ✅ | ❌ | ❌ | ❌ | ❌ |
-| [deathbycaptcha.com](http://deathbycaptcha.com) | ✅ | ❌ | ✅ | ❌ | ❌ |
+| [deathbycaptcha.com](http://deathbycaptcha.com) | ✅ | ✅ | ✅ | ❌ | ❌ |
 | [rucaptcha.com](https://rucaptcha.com?from=9863637) | ✅ | ✅ | ❌ | ❌ | ❌ |
 
 ### FunCaptcha (Arkose Labs)
@@ -161,7 +161,7 @@ if __name__ == '__main__':
 | [azcaptcha.com](https://azcaptcha.com/) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | [captcha.guru](https://captcha.guru/ru/reg/?ref=127872) | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
 | [cptch.net](https://cptch.net/auth/signup?frm=0ebc1ab34eb04f67ac320f020a8f709f) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| [deathbycaptcha.com](http://deathbycaptcha.com) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| [deathbycaptcha.com](http://deathbycaptcha.com) | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
 | [rucaptcha.com](https://rucaptcha.com?from=9863637) | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ |
 
 ### Geetest v4
@@ -172,7 +172,7 @@ if __name__ == '__main__':
 | [azcaptcha.com](https://azcaptcha.com/) | ❌ | ❌ | ❌ | ❌ |
 | [captcha.guru](https://captcha.guru/ru/reg/?ref=127872) | ❌ | ❌ | ❌ | ❌ |
 | [cptch.net](https://cptch.net/auth/signup?frm=0ebc1ab34eb04f67ac320f020a8f709f) | ❌ | ❌ | ❌ | ❌ |
-| [deathbycaptcha.com](http://deathbycaptcha.com) | ❌ | ❌ | ❌ | ❌ |
+| [deathbycaptcha.com](http://deathbycaptcha.com) | ✅ | ✅ | ❌ | ❌ |
 | [rucaptcha.com](https://rucaptcha.com?from=9863637) | ✅ | ✅ | ❌ | ✅ |
 
 ### hCaptcha

--- a/tests/data/data.py
+++ b/tests/data/data.py
@@ -434,8 +434,18 @@ OUTPUT_TEST_DATA_FOR_TASK_PREPARE_FUNC = {
         22: None,
         23: None,
         24: None,
-        25: None,
-        26: None,
+        25: {'data': dict(
+            type=8,
+            geetest_params=json.dumps(
+                {'gt': 'test2', 'challenge': 'test3', 'pageurl': 'test1'}
+            )
+        )},
+        26: {'data': dict(
+            type=8,
+            geetest_params=json.dumps(
+                {'gt': 'test2', 'challenge': 'test3', 'pageurl': 'test1'}
+            )
+        )},
         27: {'data': dict(type=7,
                           hcaptcha_params=json.dumps({'sitekey': 'test1', 'pageurl': 'test2'}))},
         28: None,
@@ -489,7 +499,12 @@ OUTPUT_TEST_DATA_FOR_TASK_PREPARE_FUNC = {
         36: None,
         37: None,
         38: None,
-        39: None,
+        39: {'data': dict(
+            type=9,
+            geetest_params=json.dumps(
+                {'captcha_id': 'test2', 'pageurl': 'test1'}
+            )
+        )},
         40: {'data': dict(
             type=4,
             token_params=json.dumps(
@@ -601,11 +616,11 @@ INPUT_TEST_DATA_FOR_TASK_PARSE_RESPONSE_FUNC = {
         4: None,
         5: get_http_resp_obj(dict(status=0, captcha='1234567890', is_correct=True, text='test')),
         6: None,
-        7: None,
+        7: get_http_resp_obj(dict(status=0, captcha='1234567890', is_correct=True, text='test')),
         8: get_http_resp_obj(dict(status=0, captcha='1234567890', is_correct=True, text='test')),
         9: None,
         10: None,
-        11: None,
+        11: get_http_resp_obj(dict(status=0, captcha='1234567890', is_correct=True, text='test'))
     }
 }
 INPUT_TEST_DATA_FOR_TASK_PARSE_RESPONSE_FUNC[CaptchaSolvingService.RUCAPTCHA] = (
@@ -672,11 +687,11 @@ OUTPUT_TEST_DATA_FOR_TASK_PARSE_RESPONSE_FUNC = {
         4: None,
         5: dict(task_id='1234567890', extra={}),
         6: None,
-        7: None,
+        7: dict(task_id='1234567890', extra={}),
         8: dict(task_id='1234567890', extra={}),
         9: None,
         10: None,
-        11: None,
+        11: dict(task_id='1234567890', extra={}),
     }
 }
 OUTPUT_TEST_DATA_FOR_TASK_PARSE_RESPONSE_FUNC[CaptchaSolvingService.RUCAPTCHA] = (

--- a/tests/test_service_module.py
+++ b/tests/test_service_module.py
@@ -33,7 +33,8 @@ SERVICE_MODULES_FOR_TEST = {
                   CaptchaType.HCAPTCHA, CaptchaType.FUNCAPTCHA),
     'cptch_net': (CaptchaType.IMAGE, CaptchaType.RECAPTCHAV2, CaptchaType.RECAPTCHAV3),
     'deathbycaptcha': (CaptchaType.IMAGE, CaptchaType.RECAPTCHAV2, CaptchaType.RECAPTCHAV3,
-                       CaptchaType.HCAPTCHA, CaptchaType.FUNCAPTCHA)
+                       CaptchaType.HCAPTCHA, CaptchaType.FUNCAPTCHA, CaptchaType.GEETEST,
+                       CaptchaType.GEETESTV4)
 }
 BASE_REQUESTS = ('GetBalance', 'GetStatus', 'ReportGood', 'ReportBad')
 TASK_REQUEST_PREPARE_PARAMS = ('self', 'captcha', 'proxy', 'user_agent', 'cookies')

--- a/unicaps/_service/deathbycaptcha.py
+++ b/unicaps/_service/deathbycaptcha.py
@@ -239,9 +239,10 @@ class SolutionRequest(GetRequest):
         captcha_type = self.source_data['task'].captcha.get_type()
         args = []
         kwargs = {}
-        print(text)
         if captcha_type in (CaptchaType.GEETEST, CaptchaType.GEETESTV4):
-            kwargs.update(eval(text))
+            json_text = text.replace("'", "\"")
+            res = json.loads(json_text)
+            kwargs.update(res)
         else:
             args.append(text)
 


### PR DESCRIPTION
Recently deathbycaptcha added support for **geetest** v3 and v4. I add support for this type of captchas in unicaps and also update the tests to include them for deathbycaptcha.
On the other hand, update the tables of the characteristics of the captchas that deathbycaptcha supports, there are some that are marked as not supported when it does. Although their documentation doesn't say so explicitly, they do support it. You can try. These are:

1. Image Case Sensitive
2. Image Numbers only
3. Image Letters only
4. Image Math
5. reCaptcha v2 Enterprise
6. reCaptcha v2 Google service
7. reCaptcha v3 Enterprise

